### PR TITLE
run scripts with the current shell

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,18 +41,18 @@ runs:
   steps:
     - run: |
         set -euo pipefail
-        "$GITHUB_ACTION_PATH/install.sh"
+        . "$GITHUB_ACTION_PATH/install.sh"
       shell: bash
       env:
         REVIEWDOG_VERSION: v0.14.2
         REVIEWDOG_TEMPDIR: ${{ runner.temp }}
     - run: |
         set -euo pipefail
-        "$GITHUB_ACTION_PATH/check-installed.sh"
+        . "$GITHUB_ACTION_PATH/check-installed.sh"
       shell: bash
     - run: |
         set -euo pipefail
-        "$GITHUB_ACTION_PATH/script.sh"
+        . "$GITHUB_ACTION_PATH/script.sh"
       shell: bash
       env:
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps

--- a/check-installed.sh
+++ b/check-installed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if ! command -v reviewdog >/dev/null 2>&1; then
   echo "reviewdog was not installed"


### PR DESCRIPTION
Some environments don't have `/bin/bash` and/or `/bin/sh`.
In these environments, you may see the following log.

```
/run/github-runner/runner1/_temp/4afc4738-e60d-4450-b422-c30a1edec6b7.sh: line 1: /run/github-runner/runner1/_actions/reviewdog/action-setup/v1/install.sh: cannot execute: required file not found
Error: Process completed with exit code 127.
```

This pull request may fix https://github.com/reviewdog/action-suggester/issues/35.
