### PR TITLE
Deprecate `fail-on-error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is diff_context. GitHub suggestions only support added and diff_context.
     default: 'diff_context'
-  fail_on_error:
-    description: |
-      Exit code for reviewdog when errors are found [true,false]
-      Default is `false`.
-    default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ inputs:
     required: false
   fail_on_error:
     description: |
+      This flag is Deprecated!
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: "false"

--- a/script.sh
+++ b/script.sh
@@ -36,4 +36,4 @@ else
   git stash pop || true
 fi
 
-exit "${EXIT_CODE}
+exit "${EXIT_CODE}"

--- a/script.sh
+++ b/script.sh
@@ -5,6 +5,11 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
+if [ "${INPUT_FAIL_ON_ERROR}" = "true" ]; then
+  echo "::warning title=fail-on-error-is-deprecated::reviewdog: -fail-on-error is deprecated"
+  INPUT_REVIEWDOG_FLAGS="${INPUT_REVIEWDOG_FLAGS} -fail-level=error "
+fi
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 TMPFILE=$(mktemp)
@@ -31,4 +36,4 @@ else
   git stash pop || true
 fi
 
-exit "${EXIT_CODE}"
+exit "${EXIT_CODE}


### PR DESCRIPTION
This pr deprecates `fail-on-error` and replace them with `-fail-level=error`.

Would be happy to implement `-fail-level` in another pr, but needs more directions on design and documentation.