### PR TITLE
Add `-fail-level` support and deprecate `-fail-on-error`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.23"
       - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
       - run: shfmt -i 2 -ci -w .

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is diff_context. GitHub suggestions only support added and diff_context.
     default: 'diff_context'
+  fail_level:
+    description: |
+      Exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to given level [none,any,info,warning,error].
+      If set to `none`, always exit with 0.
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
       Exit code for reviewdog when errors are found [true,false]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ inputs:
     description: |
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ inputs:
     description: |
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: "false"
     required: false
   reviewdog_flags:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
   fail_level:
     description: |
-      Exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to given level [none,any,info,warning,error].
+      Exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to given level [any,info,warning,error].
       If set to `none`, always exit with 0.
       Default is `none`.
     default: "none"

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,13 @@ inputs:
       Default is diff_context. GitHub suggestions only support added and diff_context.
     default: "diff_context"
     required: false
+  fail_level:
+    description: |
+      Exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to given level [none,any,info,warning,error].
+      If set to `none`, always exit with 0.
+      Default is `none`.
+    default: "none"
+    required: false
   fail_on_error:
     description: |
       Exit code for reviewdog when errors are found [true,false]
@@ -61,6 +68,7 @@ runs:
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_CLEANUP: ${{ inputs.cleanup }}

--- a/script.sh
+++ b/script.sh
@@ -19,6 +19,7 @@ reviewdog \
   -f.diff.strip=1 \
   -reporter="github-pr-review" \
   -filter-mode="${INPUT_FILTER_MODE}" \
+  -fail-level="${INPUT_FAIL_LEVEL}" \
   -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
   -level="${INPUT_LEVEL}" \
   ${INPUT_REVIEWDOG_FLAGS} <"${TMPFILE}" # INPUT_REVIEWDOG_FLAGS is intentionally split to pass multiple flags


### PR DESCRIPTION
To adapt for reviewdog 0.20.2.
https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#v0202---2024-09-16

`-fail-on-error` flag was deprecated and added `-fail-level` flag (https://github.com/reviewdog/reviewdog/pull/1854).