### PR TITLE
Allow the working directory to be specified

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "GITHUB_TOKEN"
     default: "${{ github.token }}"
     required: true
+  path:
+    description: "The directory in which reviewdog should run"
+    default: "."
+    required: false
   ### Flags for reviewdog ###
   tool_name:
     description: "Tool name to use for reviewdog reporter"
@@ -73,6 +77,7 @@ runs:
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_CLEANUP: ${{ inputs.cleanup }}
+      working-directory: ${{ inputs.path }}
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 branding:


### PR DESCRIPTION
In some of my projects I have repositories checked out in subdirectories, and am running linters and formatters in each. The action-suggester fails in these use-cases because `git diff` correctly detects that it is not being run in a git repository.

Support setting the `working-directory` by accepting a `path` input, which defaults to the current directory.