### PR TITLE
Bugfix #95 install-reviewdog.sh file not found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,9 @@ if [ -z "${TEMP}" ]; then
   fi
 fi
 
-INSTALL_SCRIPT='https://raw.githubusercontent.com/reviewdog/reviewdog/fd59714416d6d9a1c0692d872e38e7f8448df4fc/install.sh'
+INSTALL_SCRIPT='https://raw.githubusercontent.com/reviewdog/reviewdog/df70ed74df59de7ebfd9276afabd62ea2de4d7dd/install.sh'
 if [ "${VERSION}" = 'nightly' ]; then
-  INSTALL_SCRIPT='https://raw.githubusercontent.com/reviewdog/nightly/30fccfe9f47f7e6fd8b3c38aa0da11a6c9f04de7/install.sh'
+  INSTALL_SCRIPT='https://raw.githubusercontent.com/reviewdog/nightly/a41f181a20068bf2c0499054e4c19bdebc71b362/install.sh'
   VERSION='latest'
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -13,16 +13,25 @@ if [ -z "${TEMP}" ]; then
   fi
 fi
 
-INSTALL_SCRIPT="$GITHUB_ACTION_PATH/install-reviewdog.sh"
+INSTALL_SCRIPT='https://raw.githubusercontent.com/reviewdog/reviewdog/fd59714416d6d9a1c0692d872e38e7f8448df4fc/install.sh'
 if [ "${VERSION}" = 'nightly' ]; then
-  INSTALL_SCRIPT="$GITHUB_ACTION_PATH/install-nightly.sh"
+  INSTALL_SCRIPT='https://raw.githubusercontent.com/reviewdog/nightly/30fccfe9f47f7e6fd8b3c38aa0da11a6c9f04de7/install.sh'
   VERSION='latest'
 fi
 
 mkdir -p "${TEMP}/reviewdog/bin"
 
 echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
-cat "${INSTALL_SCRIPT}" | sh -s -- -b "${TEMP}/reviewdog/bin" "${VERSION}" 2>&1
+(
+  if command -v curl 2>&1 >/dev/null; then
+    curl -sfL "${INSTALL_SCRIPT}"
+  elif command -v wget 2>&1 >/dev/null; then
+    wget -O - "${INSTALL_SCRIPT}"
+  else
+    echo "curl or wget is required" >&2
+    exit 1
+  fi
+) | sh -s -- -b "${TEMP}/reviewdog/bin" "${VERSION}" 2>&1
 echo '::endgroup::'
 
 echo "${TEMP}/reviewdog/bin" >>"${GITHUB_PATH}"


### PR DESCRIPTION
### summary

This PR fixes a bug #95 introduced in the [v1.23.0](https://github.com/reviewdog/action-suggester/releases/tag/v1.23.0) release where reviewdog fails to install correctly.

To fix this, I have reverted the changes made in #93 for install.sh and restores it to the state of #70. Additionally, it updates the SHA for reviewdog's install.sh to the latest version.

https://github.com/reviewdog/reviewdog/releases/tag/v0.21.0
https://github.com/reviewdog/nightly/releases/tag/v0.21.0-nightly20250903%2Bdc416a61