### PR TITLE
fix the version name of action.yml

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5 # v1.6.4
         with:
           file: action.yml
-          version_name: REVIEWDOG_VERSION
+          version_name: reviewdog_version
           repo: reviewdog/reviewdog
           labels: "bump:minor"


### PR DESCRIPTION
https://github.com/reviewdog/action-suggester/pull/100 updates installing method of reviewdog. however, depup workflow didn't follow it.

Error log:

```plain
Run reviewdog/action-depup@680d0a6dedb9c170ec21b8e1eacf7a1133937743
  with:
    github_token: ***
    file: action.yml
    version_name: REVIEWDOG_VERSION
    repo: reviewdog/reviewdog
    exclude: \b(rc|alpha|beta)(\b|\d+)
    tag: false
/usr/bin/docker run --name f648451c2a7bfae894566ab625be387f29da1_c004af --label 9f6484 --workdir /github/workspace --rm -e "INPUT_GITHUB_TOKEN" -e "INPUT_FILE" -e "INPUT_VERSION_NAME" -e "INPUT_REPO" -e "INPUT_INCLUDE" -e "INPUT_EXCLUDE" -e "INPUT_TAG" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "GITHUB_ACTION_PATH" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/action-suggester/action-suggester":"/github/workspace" 9f6484:51c2a7bfae894566ab625be387f29da1
cannot parse REVIEWDOG_VERSION
```